### PR TITLE
When deactivating all modes, only reactivate the "stay on" mode, not all of them.

### DIFF
--- a/custom_components/lights_app/utils.py
+++ b/custom_components/lights_app/utils.py
@@ -108,7 +108,7 @@ def transformModeToHex(currentMode):
     for key, value in currentMode.items():
         binaryStr += "1" if value else "0"
     if binaryStr == "0000000":
-        binaryStr = "10000000"
+        binaryStr = "1000000"
     hex_byte = bytearray([int(binaryStr, 2)])
     return hex_byte
 


### PR DESCRIPTION
8th bit was too much, there are only 7 modes.

Otherwise the bit for the "stay on" mode is ignored when sending and all modes are deactivated. As a result, when receiving in the `transformModeFromHex`, `0000000` is turned into `1111111`, which reactivates all modes. This fix ensures that when all modes are deactivated, only the "stay on" mode is reactivated (as it was probably intended). The check in `transformModeFromHex` for `0000000` could even be removed, as the device no longer responds with `0`.

Tested with a 24m string of lights with 240 LEDs, similar to the one in [img2.jpeg](https://github.com/JurajNyiri/HomeAssistant-Lights-App/blob/main/img/img2.jpeg)
Bluetooth name: `LED-4-02-00000000`

By the way: thanks for this great Home Assistant integration!