### PR TITLE
Avoid an assumption about unset timers

### DIFF
--- a/custom_components/lights_app/utils.py
+++ b/custom_components/lights_app/utils.py
@@ -127,7 +127,7 @@ def notification_handler(entryData: dict):
             await updateEntities(entryData["entities"])
 
         # process mode and brightness data
-        if b"\x00\x00\x00\x00\x00\x00\x00\x00" in data and len(data) == 18:
+        if data.startswith(b"\x02\x00") and len(data) == 18:
             entryData["mode"] = transformModeFromHex(data[-1])
             entryData["brightness"] = get_brightness_from_bytearray(data)
             LOGGER.debug(


### PR DESCRIPTION
Reading of the mode/brightness data failed for me because I had a second timer installed and the code assumed that timers 2 and 3 were unset.
```
 byte 0-2:   \x02\x00\x0f     unknown
 byte 3:     \x63             brightness
 byte 4-7:   \x10\x00\x17\x00 timer 1 start 16:00/stop 23:00
 byte 8-11:  \x06\x0f\x07\x3b timer 2 start 06:15/stop 07:59
 byte 12-15: \x00\x00\x00\x00 timer 3 start/stop unset
 byte 16:    \x03             unknown
 byte 17:    \x40             mode
```
